### PR TITLE
Refactoring - Organize rules for each context

### DIFF
--- a/src/main/java/com/example/coreBanking/controller/AccountController.java
+++ b/src/main/java/com/example/coreBanking/controller/AccountController.java
@@ -7,7 +7,6 @@ import com.example.coreBanking.dto.request.OverdraftRequest;
 import com.example.coreBanking.dto.response.TransactionResponse;
 import com.example.coreBanking.service.AccountService;
 import com.example.coreBanking.service.TransactionService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,8 +19,8 @@ public class AccountController {
     private final AccountService accountService;
     private final TransactionService transactionService;
 
-    @Autowired
-    public AccountController(AccountService accountService, TransactionService transactionService) {
+    public AccountController(AccountService accountService,
+                             TransactionService transactionService) {
         this.accountService = accountService;
         this.transactionService = transactionService;
     }
@@ -31,38 +30,31 @@ public class AccountController {
         return ResponseEntity.ok(accountService.getAccount(accountId));
     }
 
-    @GetMapping("/balance")
-    public ResponseEntity<BalanceResponse> getBalance(@RequestParam("account_id") String accountId) {
+    @GetMapping("/{accountId}/balance")
+    public ResponseEntity<BalanceResponse> getBalance(@PathVariable String accountId) {
         return ResponseEntity.ok(accountService.getBalance(accountId));
     }
 
     @GetMapping("/{accountId}/transactions")
-    public ResponseEntity<?> getAccountTransactions(@PathVariable String accountId) {
-
-        List<TransactionResponse> transactions =
-                transactionService.getTransactionByAccountId(accountId);
-
-        if (transactions.isEmpty()) {
-            return ResponseEntity.ok("No transactions found");
-        }
-
-        return ResponseEntity.ok(transactions);
+    public ResponseEntity<List<TransactionResponse>> getAccountTransactions(@PathVariable String accountId) {
+        return ResponseEntity.ok(transactionService.getTransactionByAccountId(accountId));
     }
 
     @PostMapping
     public ResponseEntity<AccountResponse> createAccount(@RequestBody AccountRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(accountService.createAccount(request.getDocumentNumber()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(accountService.createAccount(request.getDocumentNumber()));
     }
 
     @PostMapping("/overdraft")
-    public ResponseEntity<?> setOverdraft(@RequestBody OverdraftRequest request) {
+    public ResponseEntity<Void> setOverdraft(@RequestBody OverdraftRequest request) {
         accountService.configOverdraftLimit(request.getAccountId(), request.getLimit());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reset")
-    public ResponseEntity<String> reset() {
+    public ResponseEntity<Void> reset() {
         accountService.reset();
-        return ResponseEntity.ok("System has been reset successfully");
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/coreBanking/controller/TransactionController.java
+++ b/src/main/java/com/example/coreBanking/controller/TransactionController.java
@@ -1,15 +1,12 @@
 package com.example.coreBanking.controller;
 
 import com.example.coreBanking.dto.request.EventRequest;
-import com.example.coreBanking.dto.request.TransactionRequest;
+import com.example.coreBanking.dto.response.EventResponse;
 import com.example.coreBanking.dto.response.TransactionResponse;
-import com.example.coreBanking.exception.DateTimeFormatException;
 import com.example.coreBanking.service.TransactionService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -18,20 +15,12 @@ public class TransactionController {
 
     private final TransactionService transactionService;
 
-    @Autowired
     public TransactionController(TransactionService transactionService) {
         this.transactionService = transactionService;
     }
 
-    @PostMapping
-    public ResponseEntity<TransactionResponse> createTransaction(@RequestBody TransactionRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(transactionService.createTransaction(request));
-    }
-
     @PostMapping("/event")
-    public ResponseEntity<?> handleTransactionEvent(@RequestBody EventRequest request) {
-        System.out.println(request.getType());
+    public ResponseEntity<EventResponse> handleTransaction(@RequestBody EventRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(transactionService.handleTransaction(request));
     }
@@ -44,26 +33,5 @@ public class TransactionController {
     @GetMapping("/today")
     public ResponseEntity<List<TransactionResponse>> getTransactionsToday() {
         return ResponseEntity.ok(transactionService.getTransactionsToday());
-    }
-
-    @GetMapping("/range")
-    public ResponseEntity<List<TransactionResponse>> getTransactionsInRange(
-            @RequestParam("begin") String beginDateString,
-            @RequestParam("end") String endDateString) {
-
-        LocalDateTime begin;
-        LocalDateTime end;
-        try {
-            begin = LocalDateTime.parse(beginDateString);
-            end = LocalDateTime.parse(endDateString);
-        } catch (Exception e) {
-            throw new DateTimeFormatException("Invalid date format, expected LocalDateTime format.");
-        }
-        return ResponseEntity.ok(transactionService.getTransactionsInRange(begin, end));
-    }
-
-    @GetMapping("/type/{operationTypeId}")
-    public ResponseEntity<List<TransactionResponse>> getTransactionsByType(@PathVariable int operationTypeId) {
-        return ResponseEntity.ok(transactionService.getTransactionsByType(operationTypeId));
     }
 }

--- a/src/main/java/com/example/coreBanking/dto/response/EventResponse.java
+++ b/src/main/java/com/example/coreBanking/dto/response/EventResponse.java
@@ -1,0 +1,15 @@
+package com.example.coreBanking.dto.response;
+
+public class EventResponse {
+
+    private AccountResponse origin;
+    private AccountResponse destination;
+
+    public EventResponse(AccountResponse origin, AccountResponse destination) {
+        this.origin = origin;
+        this.destination = destination;
+    }
+
+    public AccountResponse getOrigin() { return origin; }
+    public AccountResponse getDestination() { return destination; }
+}

--- a/src/main/java/com/example/coreBanking/manager/LockManager.java
+++ b/src/main/java/com/example/coreBanking/manager/LockManager.java
@@ -1,0 +1,16 @@
+package com.example.coreBanking.manager;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class LockManager {
+
+    private final ConcurrentHashMap<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    public ReentrantLock getLock(String accountId) {
+        return locks.computeIfAbsent(accountId, id -> new ReentrantLock());
+    }
+}

--- a/src/main/java/com/example/coreBanking/model/Account.java
+++ b/src/main/java/com/example/coreBanking/model/Account.java
@@ -1,4 +1,6 @@
 package com.example.coreBanking.model;
+import com.example.coreBanking.exception.InsufficientFundsException;
+
 import java.math.BigDecimal;
 
 public class Account {
@@ -35,21 +37,22 @@ public class Account {
         return balance.compareTo(BigDecimal.ZERO) < 0;
     }
 
-    public void withdraw(BigDecimal amount) {
+    public synchronized void withdraw(BigDecimal amount) {
         validateAmount(amount);
 
-        BigDecimal available = getAvailableBalance();
-
-        if (amount.compareTo(available) > 0) {
-            throw new IllegalArgumentException("Insufficient funds (including overdraft)");
+        if (amount.compareTo(getAvailableBalance()) > 0) {
+            throw new InsufficientFundsException("Insufficient funds");
         }
 
         balance = balance.subtract(amount);
     }
-    public void deposit(BigDecimal amount) {
+
+    public synchronized void deposit(BigDecimal amount) {
         validateAmount(amount);
         balance = balance.add(amount);
     }
+
+
     private void validateAmount(BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Invalid amount");

--- a/src/main/java/com/example/coreBanking/model/Transaction.java
+++ b/src/main/java/com/example/coreBanking/model/Transaction.java
@@ -2,11 +2,11 @@ package com.example.coreBanking.model;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class Transaction {
 
-    private static long counter = 0;
-
+    private static final AtomicLong counter = new AtomicLong();
     private long transactionId;
     private String accountId;
     private int operationTypeId;
@@ -14,7 +14,7 @@ public class Transaction {
     private LocalDateTime eventDate;
 
     public Transaction(String accountId, int operationTypeId, BigDecimal amount) {
-        this.transactionId = counter++;
+        this.transactionId = counter.incrementAndGet();
         this.accountId = accountId;
         this.operationTypeId = operationTypeId;
         this.amount = amount;

--- a/src/main/java/com/example/coreBanking/repository/AccountRepository.java
+++ b/src/main/java/com/example/coreBanking/repository/AccountRepository.java
@@ -8,7 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class AccountRepository {
-    private Map<String, Account> accounts = new ConcurrentHashMap<>();
+
+    private final Map<String, Account> accounts = new ConcurrentHashMap<>();
 
     public Optional<Account> findById(String id) {
         return Optional.ofNullable(accounts.get(id));

--- a/src/main/java/com/example/coreBanking/repository/TransactionRepository.java
+++ b/src/main/java/com/example/coreBanking/repository/TransactionRepository.java
@@ -4,25 +4,26 @@ import com.example.coreBanking.model.Transaction;
 import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class TransactionRepository {
 
-    private final List<Transaction> transactions = new ArrayList<>();
+    private final List<Transaction> transactions = Collections.synchronizedList(new ArrayList<>());
 
     public Transaction save(Transaction transaction) {
         transactions.add(transaction);
         return transaction;
     }
 
-    public Transaction findTransactionById(Long transactionId) {
-        for(Transaction t : transactions) {
-            if(t.getTransactionId() == transactionId) {
-                return t;
-            }
+    public Optional<Transaction> findTransactionById(Long transactionId) {
+        synchronized (transactions) {
+            return transactions.stream()
+                    .filter(t -> t.getTransactionId() == transactionId)
+                    .findFirst();
         }
-        return null;
     }
 
     public List<Transaction> findAllOperationTypeById( int operationTypeId) {
@@ -54,7 +55,6 @@ public class TransactionRepository {
         List<Transaction> listTransactionsInDate = new ArrayList<>();
         for(Transaction t : transactions) {
             LocalDateTime transactionDate = t.getEventDate();
-            //problems in compare with atributes year, month, day when comparing LocalDateTime
             if (transactionDate.toLocalDate().equals(date.toLocalDate())) {
                 listTransactionsInDate.add(t);
             }
@@ -64,17 +64,22 @@ public class TransactionRepository {
     }
 
     public List<Transaction> findByAccountId(String accountId) {
-        if (accountId == null) {
-            throw new IllegalArgumentException("AccountId cannot be null");
+        synchronized (transactions) {
+            return transactions.stream()
+                    .filter(t -> t.getAccountId().equals(accountId))
+                    .toList();
         }
-        return transactions.stream().filter(t -> t.getAccountId().equals(accountId)).toList();
     }
 
     public List<Transaction> findAll() {
-        return transactions;
+        synchronized (transactions) {
+            return new ArrayList<>(transactions);
+        }
     }
 
     public void reset() {
-        transactions.clear();
+        synchronized (transactions) {
+            transactions.clear();
+        }
     }
 }

--- a/src/main/java/com/example/coreBanking/service/AccountService.java
+++ b/src/main/java/com/example/coreBanking/service/AccountService.java
@@ -6,7 +6,6 @@ import com.example.coreBanking.exception.*;
 import com.example.coreBanking.model.Account;
 import com.example.coreBanking.repository.AccountRepository;
 import com.example.coreBanking.repository.TransactionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -21,20 +20,29 @@ public class AccountService {
 
     private final Map<String, String> documentToAccount = new ConcurrentHashMap<>();
 
-    @Autowired
-    public AccountService(AccountRepository accountRepository, TransactionRepository transactionRepository) {
+    public AccountService(AccountRepository accountRepository,
+                          TransactionRepository transactionRepository) {
         this.accountRepository = accountRepository;
         this.transactionRepository = transactionRepository;
     }
 
     public AccountResponse createAccount(String documentNumber) {
+
+        if (documentNumber == null || documentNumber.isBlank()) {
+            throw new IllegalArgumentException("Invalid document");
+        }
+
         if (documentToAccount.containsKey(documentNumber)) {
             throw new AccountAlreadyExistException("Document already has an account");
         }
+
         String accountId = UUID.randomUUID().toString();
+
         Account account = new Account(accountId, BigDecimal.ZERO);
+
         accountRepository.save(account);
         documentToAccount.put(documentNumber, accountId);
+
         return new AccountResponse(accountId, documentNumber);
     }
 
@@ -47,13 +55,29 @@ public class AccountService {
                 .map(Map.Entry::getKey)
                 .findFirst()
                 .orElse("UNKNOWN");
+
         return new AccountResponse(account.getId(), document);
     }
 
     public BalanceResponse getBalance(String accountId) {
-        return accountRepository.findById(accountId)
-                .map(account -> new BalanceResponse(account.getBalance()))
+        Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new AccountNotFoundException("Account not found"));
+
+        return new BalanceResponse(account.getBalance());
+    }
+
+    public void configOverdraftLimit(String accountId, BigDecimal limit) {
+
+        if (limit == null || limit.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Invalid overdraft limit");
+        }
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new AccountNotFoundException("Account not found"));
+
+        account.setOverdraftLimit(limit);
+
+        accountRepository.save(account);
     }
 
     public void reset() {
@@ -61,11 +85,4 @@ public class AccountService {
         transactionRepository.reset();
         documentToAccount.clear();
     }
-
-    public void configOverdraftLimit(String accountId, BigDecimal limit) {
-        Account account = accountRepository.findById(accountId).orElseThrow(() -> new AccountNotFoundException("Account not found"));
-        account.setOverdraftLimit(limit);
-        accountRepository.save(account);
-    }
-
 }

--- a/src/main/java/com/example/coreBanking/service/TransactionService.java
+++ b/src/main/java/com/example/coreBanking/service/TransactionService.java
@@ -1,214 +1,204 @@
 package com.example.coreBanking.service;
 
 import com.example.coreBanking.dto.request.EventRequest;
-import com.example.coreBanking.dto.request.TransactionRequest;
+import com.example.coreBanking.dto.response.AccountResponse;
+import com.example.coreBanking.dto.response.EventResponse;
 import com.example.coreBanking.dto.response.TransactionResponse;
 import com.example.coreBanking.exception.*;
+import com.example.coreBanking.manager.LockManager;
 import com.example.coreBanking.model.Account;
 import com.example.coreBanking.model.Transaction;
 import com.example.coreBanking.repository.AccountRepository;
 import com.example.coreBanking.repository.TransactionRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 @Service
 public class TransactionService {
 
     private final TransactionRepository transactionRepository;
     private final AccountRepository accountRepository;
+    private final LockManager lockManager;
 
-    @Autowired
-    public TransactionService(TransactionRepository transactionRepository, AccountRepository accountRepository) {
+    public TransactionService(TransactionRepository transactionRepository,
+                              AccountRepository accountRepository, LockManager lockManager) {
         this.transactionRepository = transactionRepository;
         this.accountRepository = accountRepository;
+        this.lockManager = lockManager;
     }
 
-    public TransactionResponse createTransaction(TransactionRequest request) {
-        Account account = accountRepository.findById(request.getAccountId())
-                .orElseThrow(() -> new AccountNotFoundException("Account not found"));
+    public EventResponse handleTransaction(EventRequest request) {
 
-        BigDecimal amount = normalizeAmount(request.getOperationTypeId(), request.getAmount());
-        applyTransaction(account, amount);
-        accountRepository.save(account);
-
-        Transaction transactionOnCreate = new Transaction(request.getAccountId(), request.getOperationTypeId(), amount);
-        transactionRepository.save(transactionOnCreate);
-
-        return new TransactionResponse(transactionOnCreate.getTransactionId(), transactionOnCreate.getAccountId(),
-                transactionOnCreate.getOperationTypeId(), transactionOnCreate.getAmount(), transactionOnCreate.getEventDate());
-    }
-
-    public List<TransactionResponse> getTransactionsToday() {
-        LocalDateTime today = LocalDateTime.now();
-        List<Transaction> transactions = transactionRepository.findAllTransactionOnDateTime(today);
-        return redirectTransactionResponse(transactions);
-    }
-
-    public List<TransactionResponse> getTransactionsInRange(LocalDateTime begin, LocalDateTime end) {
-        if (begin == null || end == null) {
-            throw new DateTimeFormatException("Begin or end date is invalid. Verify format date.");
-        }
-
-        List<Transaction> transactions = transactionRepository.findAllTransactionsBetweenDate(begin, end);
-        return redirectTransactionResponse(transactions);
-    }
-
-    public List<TransactionResponse> getTransactionsByType(int operationTypeId) {
-        if (operationTypeId < 1 || operationTypeId > 4) {
-            throw new OperationTypeDoesntExistException("Operation type doesn't exist");
-        }
-
-        List<Transaction> transactions = transactionRepository.findAllOperationTypeById(operationTypeId);
-        List<TransactionResponse> response = new ArrayList<>();
-
-        for (Transaction t : transactions) {
-            response.add(new TransactionResponse(
-                    t.getTransactionId(),
-                    t.getAccountId(),
-                    t.getOperationTypeId(),
-                    t.getAmount(),
-                    t.getEventDate()
-            ));
-        }
-        return response;
-    }
-
-    public TransactionResponse getTransactionById(long transactionId) {
-        Transaction idFoundedTransaction = transactionRepository.findTransactionById(transactionId);
-        if (idFoundedTransaction == null) {
-            throw new TransactionNotFoundException("Transaction not found");
-        }
-        return new TransactionResponse(
-                idFoundedTransaction.getTransactionId(),
-                idFoundedTransaction.getAccountId(),
-                idFoundedTransaction.getOperationTypeId(),
-                idFoundedTransaction.getAmount(),
-                idFoundedTransaction.getEventDate()
-        );
-    }
-
-    public List<TransactionResponse> getTransactionByAccountId (String accountId) {
-        accountRepository.findById(accountId).orElseThrow(() -> new AccountNotFoundException("Account not found."));
-        List<Transaction> allTransactions = transactionRepository.findByAccountId(accountId);
-
-        if (allTransactions == null) {
-            return new ArrayList<>();
-        }
-
-        return redirectTransactionResponse(allTransactions);
-    }
-
-    public Object handleTransaction(EventRequest request) {
         if (request.getType() == null) {
-            throw new IllegalArgumentException("Type of transaction is required");
+            throw new IllegalArgumentException("Transaction type is required");
         }
 
         return switch (request.getType()) {
-            case DEPOSIT -> handleDeposit(request);
-            case WITHDRAW  -> handleWithdraw(request);
-            case TRANSFER  -> handleTransfer(request);
-            default -> throw new IllegalArgumentException("Invalid event type: " + request.getType());
+            case DEPOSIT -> deposit(request);
+            case WITHDRAW -> withdraw(request);
+            case TRANSFER -> transfer(request);
         };
     }
 
-    private Object handleDeposit(EventRequest request) {
-        Account account = accountRepository.findById(request.getDestination())
-                .orElseGet(() -> new Account(request.getDestination(), BigDecimal.ZERO));
-        account.deposit(request.getAmount());
-        accountRepository.save(account);
+    public TransactionResponse getTransactionById(long transactionId) {
 
-        Transaction tx = new Transaction(
-                request.getDestination(),
-                4,
-                request.getAmount()
+        Transaction transaction = transactionRepository.findTransactionById(transactionId)
+                .orElseThrow(() -> new TransactionNotFoundException("Transaction not found"));
+
+        return new TransactionResponse(
+                transaction.getTransactionId(),
+                transaction.getAccountId(),
+                transaction.getOperationTypeId(),
+                transaction.getAmount(),
+                transaction.getEventDate()
         );
-
-        transactionRepository.save(tx);
-        return Map.of("destination", account);
     }
 
-    private Object handleWithdraw(EventRequest request) {
-        Account account = accountRepository.findById(request.getOrigin())
+    public List<TransactionResponse> getTransactionsToday() {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Transaction> transactions = transactionRepository.findAll().stream()
+                .filter(t -> t.getEventDate().toLocalDate().equals(now.toLocalDate()))
+                .toList();
+
+        return transactions.stream()
+                .map(t -> new TransactionResponse(
+                        t.getTransactionId(),
+                        t.getAccountId(),
+                        t.getOperationTypeId(),
+                        t.getAmount(),
+                        t.getEventDate()
+                ))
+                .toList();
+    }
+
+    public List<TransactionResponse> getTransactionByAccountId(String accountId) {
+
+        accountRepository.findById(accountId)
                 .orElseThrow(() -> new AccountNotFoundException("Account not found"));
 
-        BigDecimal available = account.getBalance().add(account.getOverdraftLimit());
-        if (available.compareTo(request.getAmount()) < 0) {
-            throw new InsufficientFundsException("Insufficient funds, including overdraft");
-        }
+        List<Transaction> transactions = transactionRepository.findByAccountId(accountId);
 
-        account.withdraw(request.getAmount());
-        accountRepository.save(account);
-
-        Transaction tx = new Transaction(
-                request.getOrigin(),
-                1,
-                request.getAmount().negate()
-        );
-
-        return Map.of("origin", account);
+        return transactions.stream()
+                .map(t -> new TransactionResponse(
+                        t.getTransactionId(),
+                        t.getAccountId(),
+                        t.getOperationTypeId(),
+                        t.getAmount(),
+                        t.getEventDate()
+                ))
+                .toList();
     }
 
-    private Object handleTransfer(EventRequest request) {
-        Account origin = accountRepository.findById(request.getOrigin())
-                .orElseThrow(() -> new AccountNotFoundException("Origin account not found"));
+    private EventResponse deposit(EventRequest request) {
 
-        Account destination = accountRepository.findById(request.getDestination())
-                .orElseGet(() -> new Account(request.getDestination(), BigDecimal.ZERO));
+        ReentrantLock lock = lockManager.getLock(request.getDestination());
+        lock.lock();
 
-        BigDecimal available = origin.getBalance().add(origin.getOverdraftLimit());
-        if (available.compareTo(request.getAmount()) < 0) {
-            throw new InsufficientFundsException("Insufficient funds, including overdraft");
-        }
+        try {
+            Account destination = accountRepository.findById(request.getDestination())
+                    .orElseThrow(() -> new AccountNotFoundException("Account not found"));
 
-        origin.withdraw(request.getAmount());
-        destination.deposit(request.getAmount());
+            destination.deposit(request.getAmount());
 
-        accountRepository.save(origin);
-        accountRepository.save(destination);
-
-        transactionRepository.save(new Transaction(
-                request.getOrigin(), 1, request.getAmount().negate()
-        ));
-
-        transactionRepository.save(new Transaction(
-                request.getDestination(), 4, request.getAmount()
-        ));
-
-        return Map.of("origin", origin, "destination", destination);
-    }
-
-    private BigDecimal normalizeAmount(int operationTypeId, BigDecimal amount) {
-        return switch (operationTypeId) {
-            case 1, 2, 3 -> amount.negate();
-            case 4 -> amount;
-            default -> throw new OperationTypeDoesntExistException("Operation type doesn't exist");
-        };
-    }
-
-    private List<TransactionResponse> redirectTransactionResponse(List<Transaction> transactions) {
-        List<TransactionResponse> resultSearchList = new ArrayList<>();
-        for (Transaction t : transactions) {
-            resultSearchList.add(new TransactionResponse(
-                    t.getTransactionId(),
-                    t.getAccountId(),
-                    t.getOperationTypeId(),
-                    t.getAmount(),
-                    t.getEventDate()
+            accountRepository.save(destination);
+            transactionRepository.save(new Transaction(
+                    destination.getId(), 4, request.getAmount()
             ));
+
+            return new EventResponse(
+                    null,
+                    new AccountResponse(destination.getId(), null)
+            );
+        } finally {
+            lock.unlock();
         }
-        return resultSearchList;
     }
 
-    private void applyTransaction(Account account, BigDecimal amount) {
-        if (amount.compareTo(BigDecimal.ZERO) < 0) {
-            account.withdraw(amount.abs());
-        } else {
-            account.deposit(amount);
+    private EventResponse withdraw(EventRequest request) {
+
+        ReentrantLock lock = lockManager.getLock(request.getOrigin());
+        lock.lock();
+
+        try {
+            Account origin = accountRepository.findById(request.getOrigin())
+                    .orElseThrow(() -> new AccountNotFoundException("Account not found"));
+
+            origin.withdraw(request.getAmount());
+
+            accountRepository.save(origin);
+            transactionRepository.save(new Transaction(
+                    origin.getId(), 1, request.getAmount().negate()
+            ));
+
+            return new EventResponse(
+                    new AccountResponse(origin.getId(), null),
+                    null
+            );
+        } finally {
+            lock.unlock();
         }
+    }
+
+    private EventResponse transfer(EventRequest request) {
+
+        String originId = request.getOrigin();
+        String destinationId = request.getDestination();
+
+        if (originId == null || destinationId == null) {
+            throw new IllegalArgumentException("Origin and destination are required");
+        }
+
+        if (originId.equals(destinationId)) {
+            throw new IllegalArgumentException("Cannot transfer to the same account");
+        }
+
+        if (request.getAmount() == null || request.getAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Invalid amount");
+        }
+
+
+        ReentrantLock lock1 = lockManager.getLock(originId);
+        ReentrantLock lock2 = lockManager.getLock(destinationId);
+
+        List<ReentrantLock> locks = Stream.of(lock1, lock2)
+                .sorted(Comparator.comparingInt(System::identityHashCode))
+                .toList();
+
+        locks.get(0).lock();
+        locks.get(1).lock();
+
+        try {
+            Account origin = accountRepository.findById(request.getOrigin())
+                    .orElseThrow(() -> new AccountNotFoundException("Origin account not found"));
+
+            Account destination = accountRepository.findById(request.getDestination())
+                    .orElseThrow(() -> new AccountNotFoundException("Destination account not found"));
+
+            origin.withdraw(request.getAmount());
+            destination.deposit(request.getAmount());
+
+            accountRepository.save(origin);
+            accountRepository.save(destination);
+
+            transactionRepository.save(new Transaction(origin.getId(), 1, request.getAmount().negate()));
+            transactionRepository.save(new Transaction(destination.getId(), 4, request.getAmount()));
+
+            return new EventResponse(
+                    new AccountResponse(origin.getId(), null),
+                    new AccountResponse(destination.getId(), null)
+            );
+        } finally {
+            locks.get(1).unlock();
+            locks.get(0).unlock();
+        }
+
     }
 }

--- a/src/test/java/com/example/coreBanking/AccountControllerTest.java
+++ b/src/test/java/com/example/coreBanking/AccountControllerTest.java
@@ -5,10 +5,10 @@ import com.example.coreBanking.dto.request.AccountRequest;
 import com.example.coreBanking.dto.request.OverdraftRequest;
 import com.example.coreBanking.dto.response.AccountResponse;
 import com.example.coreBanking.dto.response.BalanceResponse;
+import com.example.coreBanking.dto.response.TransactionResponse;
 import com.example.coreBanking.service.AccountService;
 import com.example.coreBanking.service.TransactionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,14 +17,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import com.example.coreBanking.dto.response.TransactionResponse;
 
 @WebMvcTest(AccountController.class)
 class AccountControllerTest {
@@ -41,88 +36,84 @@ class AccountControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private AccountResponse accountResponse;
-    private BalanceResponse balanceResponse;
+    @Test
+    void shouldGetAccount() throws Exception {
+        String accountId = "123";
 
-    @BeforeEach
-    void setUp() {
-        accountResponse = new AccountResponse("1234", "12345678900");
-        balanceResponse = new BalanceResponse(new BigDecimal("500.00"));
+        Mockito.when(accountService.getAccount(accountId))
+                .thenReturn(new AccountResponse(accountId, "999999999"));
+
+        mockMvc.perform(get("/api/accounts/{accountId}", accountId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountId").value(accountId))
+                .andExpect(jsonPath("$.documentNumber").value("999999999"));
     }
 
     @Test
-    void createAccount_shouldReturnCreatedAccount() throws Exception {
-        AccountRequest request = new AccountRequest();
-        request.setDocumentNumber("12345678900");
+    void shouldGetBalance() throws Exception {
+        String accountId = "123";
 
-        Mockito.when(accountService.createAccount(eq("12345678900"))).thenReturn(accountResponse);
+        Mockito.when(accountService.getBalance(accountId))
+                .thenReturn(new BalanceResponse(BigDecimal.valueOf(100)));
+
+        mockMvc.perform(get("/api/accounts/{accountId}/balance", accountId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.balance").value(100));
+    }
+
+    @Test
+    void shouldGetTransactionsByAccount() throws Exception {
+        String accountId = "123";
+
+        List<TransactionResponse> transactions = List.of(
+                new TransactionResponse(1L, accountId, 4, BigDecimal.valueOf(100), null)
+        );
+
+        Mockito.when(transactionService.getTransactionByAccountId(accountId))
+                .thenReturn(transactions);
+
+        mockMvc.perform(get("/api/accounts/{accountId}/transactions", accountId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].accountId").value(accountId))
+                .andExpect(jsonPath("$[0].amount").value(100));
+    }
+
+    @Test
+    void shouldCreateAccount() throws Exception {
+        AccountRequest request = new AccountRequest();
+        request.setDocumentNumber("999999999");
+
+        Mockito.when(accountService.createAccount("999999999"))
+                .thenReturn(new AccountResponse("123", "999999999"));
 
         mockMvc.perform(post("/api/accounts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.accountId").value("1234"))
-                .andExpect(jsonPath("$.documentNumber").value("12345678900"));
+                .andExpect(jsonPath("$.accountId").value("123"))
+                .andExpect(jsonPath("$.documentNumber").value("999999999"));
     }
 
     @Test
-    void getAccount_shouldReturnAccount() throws Exception {
-        Mockito.when(accountService.getAccount("1234")).thenReturn(accountResponse);
-
-        mockMvc.perform(get("/api/accounts/1234"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accountId").value("1234"))
-                .andExpect(jsonPath("$.documentNumber").value("12345678900"));
-    }
-
-    @Test
-    void getBalance_shouldReturnBalance() throws Exception {
-        Mockito.when(accountService.getBalance("1234")).thenReturn(balanceResponse);
-
-        mockMvc.perform(get("/api/accounts/balance")
-                        .param("account_id", "1234"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.balance").value(500.00));
-    }
-
-    @Test
-    void setOverdraft_shouldReturnOk() throws Exception {
+    void shouldSetOverdraftLimit() throws Exception {
         OverdraftRequest request = new OverdraftRequest();
-        request.setAccountId("1234");
-        request.setLimit(new BigDecimal("100.00"));
+        request.setAccountId("123");
+        request.setLimit(BigDecimal.valueOf(500));
 
         mockMvc.perform(post("/api/accounts/overdraft")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
+
+        Mockito.verify(accountService)
+                .configOverdraftLimit("123", BigDecimal.valueOf(500));
     }
 
     @Test
-    void reset_shouldReturnOk() throws Exception {
+    void shouldResetSystem() throws Exception {
         mockMvc.perform(post("/api/accounts/reset"))
                 .andExpect(status().isOk());
-    }
 
-    @Test
-    void shouldReturnTransactionsForAccount() throws Exception {
-
-        String accountId = "abc-123";
-
-        List<TransactionResponse> mockResponse = List.of(
-                new TransactionResponse(1L, accountId, 4, BigDecimal.valueOf(200), LocalDateTime.now()),
-                new TransactionResponse(2L, accountId, 1, BigDecimal.valueOf(-100), LocalDateTime.now())
-        );
-
-        when(transactionService.getTransactionByAccountId(accountId))
-                .thenReturn(mockResponse);
-
-        mockMvc.perform(get("/api/accounts/{accountId}/transactions", accountId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].accountId").value(accountId))
-                .andExpect(jsonPath("$[0].operationTypeId").value(4))
-                .andExpect(jsonPath("$[0].amount").value(200))
-                .andExpect(jsonPath("$[1].operationTypeId").value(1))
-                .andExpect(jsonPath("$[1].amount").value(-100));
+        Mockito.verify(accountService).reset();
     }
 }

--- a/src/test/java/com/example/coreBanking/AccountServiceTest.java
+++ b/src/test/java/com/example/coreBanking/AccountServiceTest.java
@@ -8,143 +8,152 @@ import com.example.coreBanking.model.Account;
 import com.example.coreBanking.repository.AccountRepository;
 import com.example.coreBanking.repository.TransactionRepository;
 import com.example.coreBanking.service.AccountService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import java.lang.reflect.Field;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class AccountServiceTest {
 
     @Mock
     private AccountRepository accountRepository;
 
     @Mock
-    TransactionRepository transactionRepository;
+    private TransactionRepository transactionRepository;
 
     @InjectMocks
     private AccountService accountService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
-    void testCreateAccount_Success() {
-        String documentNumber = "12345678900";
+    void shouldCreateAccountSuccessfully() {
 
-        AccountResponse response = accountService.createAccount(documentNumber);
+        String document = "123456789";
+
+        AccountResponse response = accountService.createAccount(document);
 
         assertNotNull(response.getAccountId());
-        assertEquals(documentNumber, response.getDocumentNumber());
-        verify(accountRepository, times(1)).save(any(Account.class));
+        assertEquals(document, response.getDocumentNumber());
+
+        verify(accountRepository).save(any(Account.class));
     }
 
     @Test
-    void testCreateAccount_AlreadyExists() {
-        String documentNumber = "12345678900";
+    void shouldThrowWhenDocumentIsInvalid() {
 
-        accountService.createAccount(documentNumber);
+        assertThrows(IllegalArgumentException.class,
+                () -> accountService.createAccount(null));
 
-        Exception exception = assertThrows(AccountAlreadyExistException.class, () -> {
-            accountService.createAccount(documentNumber);
-        });
-
-        assertEquals("Document already has an account", exception.getMessage());
+        assertThrows(IllegalArgumentException.class,
+                () -> accountService.createAccount(""));
     }
 
     @Test
-    void testGetAccount_Success() {
-        String accountId = UUID.randomUUID().toString();
+    void shouldThrowWhenAccountAlreadyExists() {
+
+        String document = "123";
+
+        accountService.createAccount(document);
+
+        assertThrows(AccountAlreadyExistException.class,
+                () -> accountService.createAccount(document));
+    }
+
+    @Test
+    void shouldGetAccountSuccessfully() {
+
+        String accountId = "acc-1";
+        String document = "123";
+
         Account account = new Account(accountId, BigDecimal.ZERO);
-        accountService.createAccount("doc123"); // adiciona no map
+
+        accountService.createAccount(document);
+
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
         AccountResponse response = accountService.getAccount(accountId);
+
         assertEquals(accountId, response.getAccountId());
     }
 
     @Test
-    void testGetAccount_NotFound() {
-        String accountId = "non-existent";
-        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+    void shouldThrowWhenAccountNotFound() {
 
-        assertThrows(AccountNotFoundException.class, () -> accountService.getAccount(accountId));
+        when(accountRepository.findById("invalid")).thenReturn(Optional.empty());
+
+        assertThrows(AccountNotFoundException.class,
+                () -> accountService.getAccount("invalid"));
     }
 
     @Test
-    void testGetBalance_Success() {
-        String accountId = UUID.randomUUID().toString();
-        Account account = new Account(accountId, BigDecimal.valueOf(100));
+    void shouldReturnBalanceSuccessfully() {
+
+        String accountId = "acc-1";
+
+        Account account = new Account(accountId, BigDecimal.valueOf(200));
+
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
         BalanceResponse response = accountService.getBalance(accountId);
-        assertEquals(BigDecimal.valueOf(100), response.getBalance());
+
+        assertEquals(BigDecimal.valueOf(200), response.getBalance());
     }
 
     @Test
-    void testGetBalance_NotFound() {
-        String accountId = "non-existent";
-        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+    void shouldThrowWhenBalanceAccountNotFound() {
 
-        assertThrows(AccountNotFoundException.class, () -> accountService.getBalance(accountId));
-    }
+        when(accountRepository.findById("invalid")).thenReturn(Optional.empty());
 
-    @BeforeEach
-    void setup() throws Exception {
-        accountRepository = mock(AccountRepository.class);
-        transactionRepository = mock(TransactionRepository.class);
-
-        accountService = new AccountService(accountRepository , transactionRepository);
-
-        Field field = AccountService.class.getDeclaredField("transactionRepository");
-        field.setAccessible(true);
-        field.set(accountService, transactionRepository);
+        assertThrows(AccountNotFoundException.class,
+                () -> accountService.getBalance("invalid"));
     }
 
     @Test
-    void shouldResetSystemSuccessfully() throws Exception {
+    void shouldSetOverdraftLimitSuccessfully() {
 
-        Field mapField = AccountService.class.getDeclaredField("documentToAccount");
-        mapField.setAccessible(true);
-        Map<String, String> map = (Map<String, String>) mapField.get(accountService);
-        map.put("123", "acc-1");
+        String accountId = "acc-1";
+
+        Account account = new Account(accountId, BigDecimal.ZERO);
+
+        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
+
+        accountService.configOverdraftLimit(accountId, BigDecimal.valueOf(500));
+
+        assertEquals(BigDecimal.valueOf(500), account.getOverdraftLimit());
+
+        verify(accountRepository).save(account);
+    }
+
+    @Test
+    void shouldThrowWhenOverdraftInvalid() {
+
+        assertThrows(IllegalArgumentException.class,
+                () -> accountService.configOverdraftLimit("acc-1", null));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> accountService.configOverdraftLimit("acc-1", BigDecimal.valueOf(-10)));
+    }
+
+    @Test
+    void shouldThrowWhenSettingOverdraftForNonexistentAccount() {
+
+        when(accountRepository.findById("invalid")).thenReturn(Optional.empty());
+
+        assertThrows(AccountNotFoundException.class,
+                () -> accountService.configOverdraftLimit("invalid", BigDecimal.valueOf(100)));
+    }
+
+    @Test
+    void shouldResetSystem() {
 
         accountService.reset();
 
-        verify(accountRepository, times(1)).reset();
-        verify(transactionRepository, times(1)).reset();
-
-        assert map.isEmpty();
-    }
-
-    @Test
-    void testConfigOverdraftLimit_Success() {
-        String accountId = UUID.randomUUID().toString();
-        Account account = new Account(accountId, BigDecimal.ZERO);
-        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
-
-        BigDecimal limit = BigDecimal.valueOf(500);
-        accountService.configOverdraftLimit(accountId, limit);
-
-        assertEquals(limit, account.getOverdraftLimit());
-        verify(accountRepository, times(1)).save(account);
-    }
-
-    @Test
-    void testConfigOverdraftLimit_AccountNotFound() {
-        String accountId = "non-existent";
-        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
-
-        BigDecimal limit = BigDecimal.valueOf(500);
-        assertThrows(AccountNotFoundException.class, () -> accountService.configOverdraftLimit(accountId, limit));
+        verify(accountRepository).reset();
+        verify(transactionRepository).reset();
     }
 }

--- a/src/test/java/com/example/coreBanking/LockManagerTest.java
+++ b/src/test/java/com/example/coreBanking/LockManagerTest.java
@@ -1,0 +1,66 @@
+package com.example.coreBanking;
+
+import com.example.coreBanking.manager.LockManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LockManagerTest {
+
+    private LockManager lockManager;
+
+    @BeforeEach
+    void setUp() {
+        lockManager = new LockManager();
+    }
+
+    @Test
+    @DisplayName("Deve retornar a mesma instância de Lock para o mesmo ID de conta")
+    void shouldReturnSameLockForSameAccountId() {
+        String accountId = "acc-123";
+
+        ReentrantLock firstCall = lockManager.getLock(accountId);
+        ReentrantLock secondCall = lockManager.getLock(accountId);
+
+        assertNotNull(firstCall, "O lock não deve ser nulo");
+        assertSame(firstCall, secondCall, "Devem ser exatamente a mesma instância de ReentrantLock");
+    }
+
+    @Test
+    @DisplayName("Deve retornar instâncias diferentes para IDs de conta diferentes")
+    void shouldReturnDifferentLocksForDifferentAccountIds() {
+        String accountId1 = "acc-1";
+        String accountId2 = "acc-2";
+
+        ReentrantLock lock1 = lockManager.getLock(accountId1);
+        ReentrantLock lock2 = lockManager.getLock(accountId2);
+
+        assertNotSame(lock1, lock2, "Contas diferentes devem ter instâncias de trava independentes");
+    }
+
+    @Test
+    @DisplayName("Deve garantir a mesma instância mesmo sob múltiplas chamadas concorrentes")
+    void shouldBeThreadSafeWhenCreatingLocks() throws ExecutionException, InterruptedException {
+        String accountId = "acc-concurrent";
+        int numberOfThreads = 100;
+        List<CompletableFuture<ReentrantLock>> futures = new ArrayList<>();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            futures.add(CompletableFuture.supplyAsync(() -> lockManager.getLock(accountId)));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        ReentrantLock primaryLock = futures.get(0).get();
+        for (CompletableFuture<ReentrantLock> future : futures) {
+            assertSame(primaryLock, future.get(), "Mesmo sob estresse, todos devem receber a mesma instância");
+        }
+    }
+}

--- a/src/test/java/com/example/coreBanking/TransactionControllerTest.java
+++ b/src/test/java/com/example/coreBanking/TransactionControllerTest.java
@@ -2,11 +2,10 @@ package com.example.coreBanking;
 
 import com.example.coreBanking.controller.TransactionController;
 import com.example.coreBanking.dto.request.EventRequest;
-import com.example.coreBanking.dto.request.TransactionRequest;
+import com.example.coreBanking.dto.response.EventResponse;
 import com.example.coreBanking.dto.response.TransactionResponse;
 import com.example.coreBanking.service.TransactionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +15,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.List;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TransactionController.class)
 class TransactionControllerTest {
@@ -35,96 +31,67 @@ class TransactionControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private TransactionResponse sampleTransaction;
-
-    @BeforeEach
-    void setUp() {
-        sampleTransaction = new TransactionResponse(
-                1L,
-                "account-123",
-                4,
-                BigDecimal.valueOf(100),
-                LocalDateTime.now()
-        );
-    }
-
     @Test
-    void testCreateTransaction() throws Exception {
-        TransactionRequest request =  new TransactionRequest();
-        request.setAccountId("account-123");
-        request.setOperationTypeId(4);
-        request.setAmount(BigDecimal.valueOf(100));
+    void shouldHandleDepositEvent() throws Exception {
 
-        Mockito.when(transactionService.createTransaction(any(TransactionRequest.class)))
-                .thenReturn(sampleTransaction);
-
-        mockMvc.perform(post("/api/transactions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.accountId").value("account-123"))
-                .andExpect(jsonPath("$.amount").value(100));
-    }
-
-    @Test
-    void testHandleTransactionEvent() throws Exception {
         EventRequest request = new EventRequest();
         request.setType(EventRequest.EventType.DEPOSIT);
-        request.setDestination("account-123");
+        request.setDestination("acc-1");
         request.setAmount(BigDecimal.valueOf(100));
 
-        Mockito.when(transactionService.handleTransaction(any(EventRequest.class)))
-                .thenReturn(Collections.singletonMap("destination", sampleTransaction));
+        EventResponse response = new EventResponse(null, null);
+
+        Mockito.when(transactionService.handleTransaction(Mockito.any()))
+                .thenReturn(response);
 
         mockMvc.perform(post("/api/transactions/event")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.destination.accountId").value("account-123"));
+                .andExpect(status().isCreated());
     }
 
     @Test
-    void testGetTransactionById() throws Exception {
-        Mockito.when(transactionService.getTransactionById(1L))
-                .thenReturn(sampleTransaction);
+    void shouldGetTransactionById() throws Exception {
 
-        mockMvc.perform(get("/api/transactions/1"))
+        long transactionId = 1L;
+
+        TransactionResponse response = new TransactionResponse(
+                transactionId,
+                "acc-1",
+                4,
+                BigDecimal.valueOf(100),
+                LocalDateTime.now()
+        );
+
+        Mockito.when(transactionService.getTransactionById(transactionId))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/transactions/{id}", transactionId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.transactionId").value(1));
+                .andExpect(jsonPath("$.transactionId").value(transactionId))
+                .andExpect(jsonPath("$.accountId").value("acc-1"))
+                .andExpect(jsonPath("$.amount").value(100));
     }
 
     @Test
-    void testGetTransactionsToday() throws Exception {
+    void shouldGetTransactionsToday() throws Exception {
+
+        List<TransactionResponse> list = List.of(
+                new TransactionResponse(
+                        1L,
+                        "acc-1",
+                        4,
+                        BigDecimal.valueOf(100),
+                        LocalDateTime.now()
+                )
+        );
+
         Mockito.when(transactionService.getTransactionsToday())
-                .thenReturn(Collections.singletonList(sampleTransaction));
+                .thenReturn(list);
 
         mockMvc.perform(get("/api/transactions/today"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].accountId").value("account-123"));
-    }
-
-    @Test
-    void testGetTransactionsInRange() throws Exception {
-        String begin = "2025-08-16T00:00:00";
-        String end = "2025-08-16T23:59:59";
-
-        Mockito.when(transactionService.getTransactionsInRange(any(LocalDateTime.class), any(LocalDateTime.class)))
-                .thenReturn(Collections.singletonList(sampleTransaction));
-
-        mockMvc.perform(get("/api/transactions/range")
-                        .param("begin", begin)
-                        .param("end", end))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].accountId").value("account-123"));
-    }
-
-    @Test
-    void testGetTransactionsByType() throws Exception {
-        Mockito.when(transactionService.getTransactionsByType(4))
-                .thenReturn(Collections.singletonList(sampleTransaction));
-
-        mockMvc.perform(get("/api/transactions/type/4"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].operationTypeId").value(4));
+                .andExpect(jsonPath("$[0].accountId").value("acc-1"))
+                .andExpect(jsonPath("$[0].amount").value(100));
     }
 }

--- a/src/test/java/com/example/coreBanking/TransactionServiceTest.java
+++ b/src/test/java/com/example/coreBanking/TransactionServiceTest.java
@@ -1,13 +1,17 @@
 package com.example.coreBanking;
 
-import com.example.coreBanking.dto.request.TransactionRequest;
+import com.example.coreBanking.dto.request.EventRequest;
+import com.example.coreBanking.dto.response.EventResponse;
 import com.example.coreBanking.dto.response.TransactionResponse;
 import com.example.coreBanking.exception.AccountNotFoundException;
+import com.example.coreBanking.exception.InsufficientFundsException;
+import com.example.coreBanking.manager.LockManager;
 import com.example.coreBanking.model.Account;
 import com.example.coreBanking.model.Transaction;
 import com.example.coreBanking.repository.AccountRepository;
 import com.example.coreBanking.repository.TransactionRepository;
 import com.example.coreBanking.service.TransactionService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -31,80 +36,88 @@ class TransactionServiceTest {
     @InjectMocks
     private TransactionService transactionService;
 
-    @Test
-    void shouldCreateDepositTransaction() {
+    @Mock
+    private LockManager lockManager;
 
+    @BeforeEach
+    void setup() {
+        lenient().when(lockManager.getLock(anyString()))
+                .thenReturn(new ReentrantLock());
+    }
+
+    @Test
+    void shouldHandleDepositEvent() {
         String accountId = "acc-1";
         Account account = new Account(accountId, BigDecimal.ZERO);
 
-        TransactionRequest request = new TransactionRequest(accountId, 4, BigDecimal.valueOf(100));
+        EventRequest request = new EventRequest();
+        request.setType(EventRequest.EventType.DEPOSIT);
+        request.setDestination(accountId);
+        request.setAmount(BigDecimal.valueOf(100));
 
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
-        TransactionResponse response = transactionService.createTransaction(request);
+        EventResponse response = transactionService.handleTransaction(request);
 
-        assertEquals(accountId, response.getAccountId());
         assertEquals(BigDecimal.valueOf(100), account.getBalance());
-
         verify(accountRepository).save(account);
         verify(transactionRepository).save(any(Transaction.class));
     }
 
     @Test
-    void shouldCreateWithdrawUsingOverdraft() {
-
+    void shouldHandleWithdrawUsingOverdraft() {
         String accountId = "acc-1";
         Account account = new Account(accountId, BigDecimal.valueOf(100));
         account.setOverdraftLimit(BigDecimal.valueOf(200));
 
-        TransactionRequest request = new TransactionRequest(accountId, 1, BigDecimal.valueOf(250));
+        EventRequest request = new EventRequest();
+        request.setType(EventRequest.EventType.WITHDRAW);
+        request.setOrigin(accountId);
+        request.setAmount(BigDecimal.valueOf(250));
 
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
-        transactionService.createTransaction(request);
+        transactionService.handleTransaction(request);
 
         assertEquals(BigDecimal.valueOf(-150), account.getBalance());
-
         verify(accountRepository).save(account);
-        verify(transactionRepository).save(any(Transaction.class));
     }
 
     @Test
-    void shouldThrowWhenInsufficientFundsEvenWithOverdraft() {
-
+    void shouldThrowWhenInsufficientFunds() {
         String accountId = "acc-1";
         Account account = new Account(accountId, BigDecimal.valueOf(100));
         account.setOverdraftLimit(BigDecimal.valueOf(50));
 
-        TransactionRequest request = new TransactionRequest(accountId, 1, BigDecimal.valueOf(200));
+        EventRequest request = new EventRequest();
+        request.setType(EventRequest.EventType.WITHDRAW);
+        request.setOrigin(accountId);
+        request.setAmount(BigDecimal.valueOf(200));
 
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
-        assertThrows(IllegalArgumentException.class,
-                () -> transactionService.createTransaction(request));
+        assertThrows(InsufficientFundsException.class,
+                () -> transactionService.handleTransaction(request));
     }
 
     @Test
     void shouldThrowWhenAccountNotFound() {
-
         String accountId = "invalid";
-
-        TransactionRequest request = new TransactionRequest(accountId, 4, BigDecimal.valueOf(100));
+        EventRequest request = new EventRequest();
+        request.setType(EventRequest.EventType.DEPOSIT);
+        request.setDestination(accountId);
+        request.setAmount(BigDecimal.valueOf(100));
 
         when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
 
         assertThrows(AccountNotFoundException.class,
-                () -> transactionService.createTransaction(request));
+                () -> transactionService.handleTransaction(request));
     }
-
 
     @Test
     void shouldReturnTransactionsByAccountId() {
-
         String accountId = "acc-1";
-
         Account account = new Account(accountId, BigDecimal.ZERO);
-
         List<Transaction> transactions = List.of(
                 new Transaction(accountId, 4, BigDecimal.valueOf(100)),
                 new Transaction(accountId, 1, BigDecimal.valueOf(-50))
@@ -113,18 +126,15 @@ class TransactionServiceTest {
         when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
         when(transactionRepository.findByAccountId(accountId)).thenReturn(transactions);
 
-        List<TransactionResponse> response =
-                transactionService.getTransactionByAccountId(accountId);
+        List<TransactionResponse> response = transactionService.getTransactionByAccountId(accountId);
 
         assertEquals(2, response.size());
-        assertEquals(accountId, response.get(0).getAccountId());
+        verify(transactionRepository).findByAccountId(accountId);
     }
 
     @Test
     void shouldThrowWhenAccountNotFoundOnHistory() {
-
         String accountId = "invalid";
-
         when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
 
         assertThrows(AccountNotFoundException.class,


### PR DESCRIPTION
I've reorganized the logic into transaction and account cores using a shared cascade event. Validation is now centralized in the service layer to remove route-level duplication. I also integrated a LockManager to handle thread safety for all transaction types (deposit, transfer, and withdraw).